### PR TITLE
Add prospectus dashboard wired for Xano

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
-# GlowSkill
+# GlowSkill Prospectus Dashboard
+
+This project hosts a Next.js App Router workspace for the Glowskill prospectus and revenue dashboard. It ships with Tailwind CSS, shadcn/ui primitives, Recharts visualisations, and PDF export support so it can be connected directly to Xano.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000` and navigate to `/prospectus`.
+
+> **Note:** the online package registry might require credentials. If installation fails, mirror the dependencies to a reachable registry before running the commands above.
+
+## Environment variables
+
+Set the base URL of your Xano workspace in `.env.local`:
+
+```
+NEXT_PUBLIC_XANO_BASE=https://your-xano-instance.com/api
+```
+
+## Data endpoints
+
+The dashboard expects the following Xano endpoints:
+
+- `GET /revenue/streams?scenario=conservative|realistic|optimistic` → returns 24 monthly revenue points with keys `month`, `estPro`, `infPro`, `cabina`, `saloniPro`.
+- `GET /kpi/summary` (optional) → returns a JSON object with headline KPIs (`stylists`, `salons`, `proStylists`, `proInfluencers`, `bookingsMonth24`).
+
+If the request fails or the environment variable is missing, the UI automatically falls back to demo data generated on the client.
+
+## PDF export
+
+The prospectus page includes an **Export PDF** button that captures the whole dashboard using `html2canvas` and creates an A4 PDF via `jspdf`.
+
+## Project structure
+
+```
+src/
+  app/
+    layout.tsx
+    page.tsx
+    prospectus/
+      page.tsx
+  components/
+    ScenarioSelect.tsx
+    ProspectusCopy.tsx
+    charts/
+      RevenueByStream.tsx
+      TotalRevenue.tsx
+    ui/
+      button.tsx
+      card.tsx
+      select.tsx
+  lib/
+    api.ts
+  styles/
+    globals.css
+```
+
+## Testing
+
+The project includes standard Next.js scripts:
+
+- `npm run lint`
+- `npm run build`
+
+Run them once dependencies are installed and the registry is reachable.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    turbo: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "glowskill",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@radix-ui/react-select": "2.0.0",
+    "@radix-ui/react-slot": "1.0.2",
+    "class-variance-authority": "0.7.0",
+    "clsx": "2.1.0",
+    "html2canvas": "1.4.1",
+    "jspdf": "2.5.1",
+    "lucide-react": "0.364.0",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "recharts": "2.10.4",
+    "tailwind-merge": "2.2.1",
+    "tailwindcss-animate": "1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.74",
+    "@types/react-dom": "18.2.23",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import "@/styles/globals.css";
+import { cn } from "@/lib/utils";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Glowskill Prospectus",
+  description: "Prospectus and revenue dashboard connected to Xano",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={cn("min-h-screen bg-background font-sans antialiased", inter.className)}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-6 text-center">
+      <div className="space-y-3">
+        <h1 className="text-4xl font-bold tracking-tight">Glowskill Dashboard Workspace</h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Explore the 24-month plan, revenue projections, and qualitative prospectus for Glowskill.
+        </p>
+      </div>
+      <Button asChild size="lg">
+        <Link href="/prospectus">
+          Open Prospectus Dashboard
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Link>
+      </Button>
+    </main>
+  );
+}

--- a/src/app/prospectus/page.tsx
+++ b/src/app/prospectus/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+import { FileDown, RefreshCw } from "lucide-react";
+
+import { ScenarioSelect } from "@/components/ScenarioSelect";
+import { RevenueByStreamChart } from "@/components/charts/RevenueByStream";
+import { TotalRevenueChart } from "@/components/charts/TotalRevenue";
+import { ProspectusCopy } from "@/components/ProspectusCopy";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchKpis, fetchRevenue, type RevenuePoint, type Scenario } from "@/lib/api";
+
+export default function ProspectusPage() {
+  const [scenario, setScenario] = useState<Scenario>("realistic");
+  const [data, setData] = useState<RevenuePoint[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [kpis, setKpis] = useState<Record<string, number> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const loadData = useCallback(async (selectedScenario: Scenario) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [revenue, summary] = await Promise.all([fetchRevenue(selectedScenario), fetchKpis()]);
+      setData(revenue);
+      setKpis(summary);
+      if (!process.env.NEXT_PUBLIC_XANO_BASE) {
+        setError("NEXT_PUBLIC_XANO_BASE not set. Showing demo data.");
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Unable to load data from Xano. Showing demo data.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(scenario);
+  }, [loadData, scenario]);
+
+  const handleRefresh = useCallback(() => {
+    loadData(scenario);
+  }, [loadData, scenario]);
+
+  const handleExportPdf = useCallback(async () => {
+    if (!containerRef.current) return;
+    const canvas = await html2canvas(containerRef.current, {
+      scale: 2,
+      useCORS: true,
+      scrollY: -window.scrollY,
+    });
+    const imgData = canvas.toDataURL("image/png");
+    const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    const imgProps = pdf.getImageProperties(imgData);
+    const ratio = Math.min(pageWidth / imgProps.width, pageHeight / imgProps.height);
+    const width = imgProps.width * ratio;
+    const height = imgProps.height * ratio;
+    const marginX = (pageWidth - width) / 2;
+    const marginY = (pageHeight - height) / 2;
+
+    pdf.addImage(imgData, "PNG", marginX, marginY, width, height);
+    pdf.save(`glowskill-prospectus-${scenario}.pdf`);
+  }, [scenario]);
+
+  const headlineKpis = useMemo(() => {
+    if (!kpis) return null;
+    const mapping: Record<string, string> = {
+      stylists: "Estetiste",
+      salons: "Saloni",
+      proStylists: "Estetiste PRO",
+      proInfluencers: "Influencer PRO",
+      bookingsMonth24: "Cabina prenot./mese 24",
+    };
+    return Object.entries(mapping)
+      .filter(([key]) => typeof kpis[key] === "number")
+      .map(([key, label]) => ({
+        key,
+        label,
+        value: kpis[key].toLocaleString(),
+      }));
+  }, [kpis]);
+
+  return (
+    <div ref={containerRef} className="mx-auto flex max-w-6xl flex-col gap-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Glowskill Prospectus &amp; Revenue Dashboard</h1>
+        <p className="text-sm text-muted-foreground">Early-stage plan • 24 months • Xano-connected</p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <ScenarioSelect value={scenario} onChange={setScenario} />
+        <Button variant="outline" onClick={handleRefresh} className="gap-2">
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </Button>
+        <Button onClick={handleExportPdf} className="gap-2">
+          <FileDown className="h-4 w-4" />
+          Export PDF
+        </Button>
+      </div>
+
+      {headlineKpis && headlineKpis.length > 0 && (
+        <Card className="shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">Key KPIs</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-5">
+            {headlineKpis.map((item) => (
+              <div key={item.key} className="rounded-lg bg-muted/60 p-4 text-center">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.label}</p>
+                <p className="mt-1 text-2xl font-semibold">{item.value}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-dashed border-amber-400 bg-amber-50 p-4 text-sm text-amber-900">
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <RevenueByStreamChart data={data} loading={loading} error={error} />
+        <TotalRevenueChart data={data} />
+      </div>
+
+      <ProspectusCopy />
+    </div>
+  );
+}

--- a/src/components/ProspectusCopy.tsx
+++ b/src/components/ProspectusCopy.tsx
@@ -1,0 +1,94 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function ProspectusCopy() {
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Prospectus</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Vision, revenue streams, costs, metrics, and milestones guiding the 24-month roadmap.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6 text-sm leading-relaxed">
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold">Vision &amp; Product</h3>
+          <p>
+            Glowskill connette <strong>freelancer beauty</strong>, <strong>saloni</strong> e <strong>creator</strong> in un ecosistema
+            dove le prenotazioni evolvono in <em>collab sessions</em> con milestone narrative. La piattaforma è dual-mode
+            (Freelancer ↔ Influencer), integra <em>cabina-sharing</em> stile Airbnb per cabine dei centri e abilita portfolio/storytelling utili a brand e clienti.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold">Revenue Streams</h3>
+          <ul className="ml-5 list-disc space-y-1.5">
+            <li>
+              <strong>Cabina-sharing:</strong> fee per booking (es. €10). Plateau a 24 mesi: <strong>top 30 saloni = 2
+              prenot./giorno</strong>, gli altri al <strong>20%</strong> di quel volume (regola di Pareto).
+            </li>
+            <li>
+              <strong>Estetiste PRO</strong> (<em>dal mese 6</em>): €10/mese; conversione target <strong>20%</strong> degli iscritti.
+            </li>
+            <li>
+              <strong>Influencer/UGC PRO</strong> (<em>dal mese 12</em>): €15/mese; conversione target <strong>20%</strong> dei creator attivi.
+            </li>
+            <li>
+              <strong>Saloni PRO</strong> (<em>adozione progressiva</em>): prezzo mensile (79–99€). Nel modello base: <strong>€99</strong> con
+              conversione che cresce <strong>0%→5% (mesi 12–14) → 15% (15–17) → 30–40% (18–24)</strong>.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold">Cost Structure</h3>
+          <ul className="ml-5 list-disc space-y-1.5">
+            <li>
+              <strong>Sviluppo:</strong> €600/mese × 5 mesi; poi continuous improvement.
+            </li>
+            <li>
+              <strong>Infra &amp; AI:</strong> ~€200/mese (token AI, Xano, server).
+            </li>
+            <li>
+              <strong>Customer Support:</strong> €400/mese (ENG) o €900/mese (IT–Albania); 1–2 persone per 4 mesi.
+            </li>
+            <li>
+              <strong>Amministrazione/Legale:</strong> €1.500 una tantum.
+            </li>
+            <li>
+              <strong>Sales:</strong> €1.200/mese.
+            </li>
+            <li>
+              <strong>Stipendi cofounder:</strong> <strong>€2.000/mese ciascuno</strong> nel primo anno; <strong>€2.500/mese</strong> dal secondo <em>solo se</em> le revenue effettive sono entro <strong>±20%</strong> rispetto al business plan.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold">Key Metrics</h3>
+          <ul className="ml-5 list-disc space-y-1.5">
+            <li>Estetiste iscritte (crescita esponenziale, -20% sui primi 6 mesi rispetto al target).</li>
+            <li>Prenotazioni cabina/mese (plateau a 24 mesi: 2/giorno top 30, 20% gli altri).</li>
+            <li>MRR per stream: Estetiste PRO, Influencer PRO, Cabina-sharing, Saloni PRO.</li>
+            <li>Conversioni PRO (20% estetiste, 20% creator; saloni 0→40%).</li>
+            <li>CAC: ~€100/salone; ~€5/estetista (Italia).</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-base font-semibold">Milestones 0–24 mesi</h3>
+          <ul className="ml-5 list-disc space-y-1.5">
+            <li>
+              <strong>0–6 mesi:</strong> crescita community; avvio Estetiste PRO; prime partnership cabine.
+            </li>
+            <li>
+              <strong>6–12 mesi:</strong> lancio Influencer/UGC PRO; accelerazione verso plateau cabina.
+            </li>
+            <li>
+              <strong>12–24 mesi:</strong> adozione progressiva Saloni PRO (5%→15%→30–40%).
+            </li>
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ScenarioSelect.tsx
+++ b/src/components/ScenarioSelect.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Scenario } from "@/lib/api";
+
+const LABELS: Record<Scenario, string> = {
+  conservative: "Conservative",
+  realistic: "Realistic",
+  optimistic: "Optimistic",
+};
+
+export type ScenarioSelectProps = {
+  value: Scenario;
+  onChange: (scenario: Scenario) => void;
+};
+
+export function ScenarioSelect({ value, onChange }: ScenarioSelectProps) {
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as Scenario)}>
+      <SelectTrigger className="w-[220px]">
+        <SelectValue placeholder="Select scenario" />
+      </SelectTrigger>
+      <SelectContent>
+        {Object.entries(LABELS).map(([key, label]) => (
+          <SelectItem key={key} value={key}>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/charts/RevenueByStream.tsx
+++ b/src/components/charts/RevenueByStream.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RevenuePoint } from "@/lib/api";
+
+export type RevenueByStreamProps = {
+  data: RevenuePoint[];
+  loading: boolean;
+  error: string | null;
+};
+
+export function RevenueByStreamChart({ data, loading, error }: RevenueByStreamProps) {
+  return (
+    <Card className="shadow-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-xl">Revenue by Stream</CardTitle>
+        <p className="text-sm text-muted-foreground">Monthly revenue per stream (EUR)</p>
+      </CardHeader>
+      <CardContent className="h-[320px]">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Loading revenue data…
+          </div>
+        ) : error ? (
+          <div className="flex h-full items-center justify-center text-center text-sm text-destructive">
+            Unable to load from Xano. Displaying fallback demo data.
+          </div>
+        ) : null}
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 16, right: 12, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => `€${value}`} width={80} />
+            <Tooltip formatter={(value: number, name: string) => [`€${value.toLocaleString()}`, name]} />
+            <Legend />
+            <Line type="monotone" dataKey="estPro" name="Estetiste PRO" stroke="#6366F1" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="infPro" name="Influencer/UGC PRO" stroke="#22C55E" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="cabina" name="Cabina-sharing" stroke="#F97316" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="saloniPro" name="Saloni PRO" stroke="#14B8A6" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/charts/TotalRevenue.tsx
+++ b/src/components/charts/TotalRevenue.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RevenuePoint } from "@/lib/api";
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+export type TotalRevenueChartProps = {
+  data: RevenuePoint[];
+};
+
+const toTotalSeries = (points: RevenuePoint[]) =>
+  points.map((point) => ({
+    month: point.month,
+    total: point.estPro + point.infPro + point.cabina + point.saloniPro,
+  }));
+
+export function TotalRevenueChart({ data }: TotalRevenueChartProps) {
+  const totalSeries = toTotalSeries(data);
+  return (
+    <Card className="shadow-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-xl">Total Revenue</CardTitle>
+        <p className="text-sm text-muted-foreground">Aggregate monthly revenue (EUR)</p>
+      </CardHeader>
+      <CardContent className="h-[320px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={totalSeries} margin={{ top: 16, right: 12, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" tickLine={false} axisLine={false} />
+            <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => `€${value}`} width={80} />
+            <Tooltip formatter={(value: number) => [`€${value.toLocaleString()}`, "Totale" as const]} />
+            <Line type="monotone" dataKey="total" stroke="#1F2937" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref as any}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("rounded-xl border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        position === "popper" && "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronUp className="h-4 w-4" />
+      </SelectPrimitive.ScrollUpButton>
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronDown className="h-4 w-4" />
+      </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label ref={ref} className={cn("px-2 py-1.5 text-sm font-semibold", className)} {...props} />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectLabel, SelectItem, SelectSeparator };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,71 @@
+export type RevenuePoint = {
+  month: number;
+  estPro: number;
+  infPro: number;
+  cabina: number;
+  saloniPro: number;
+};
+
+export type Scenario = "conservative" | "realistic" | "optimistic";
+
+const SCENARIO_MULTIPLIERS: Record<Scenario, number> = {
+  conservative: 0.8,
+  realistic: 1,
+  optimistic: 1.2,
+};
+
+const buildDemoData = (): RevenuePoint[] =>
+  Array.from({ length: 24 }, (_, index) => {
+    const month = index + 1;
+    const estPro = month < 6 ? 0 : Math.round(200 * Math.log(month));
+    const infPro = month < 12 ? 0 : Math.round(250 * Math.log(month - 10));
+    const cabina = Math.round(500 * (1 / (1 + Math.exp(-0.35 * (month - 18)))));
+    const saloniPro = month < 12 ? 0 : Math.round(month >= 18 ? (month - 11) * 90 : (month - 11) * 50);
+    return { month, estPro, infPro, cabina, saloniPro };
+  });
+
+const scaleDemoData = (data: RevenuePoint[], scenario: Scenario) => {
+  const multiplier = SCENARIO_MULTIPLIERS[scenario];
+  if (multiplier === 1) return data;
+  return data.map((point) => ({
+    ...point,
+    estPro: Math.round(point.estPro * multiplier),
+    infPro: Math.round(point.infPro * multiplier),
+    cabina: Math.round(point.cabina * multiplier),
+    saloniPro: Math.round(point.saloniPro * multiplier),
+  }));
+};
+
+export async function fetchRevenue(scenario: Scenario = "realistic"): Promise<RevenuePoint[]> {
+  const base = process.env.NEXT_PUBLIC_XANO_BASE;
+  const fallback = scaleDemoData(buildDemoData(), scenario);
+  if (!base) return fallback;
+
+  const url = `${base.replace(/\/$/, "")}/revenue/streams?scenario=${scenario}`;
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error("Bad status");
+    const data: unknown = await response.json();
+    if (Array.isArray(data) && data.length) {
+      return data as RevenuePoint[];
+    }
+  } catch (error) {
+    console.error("Failed to load revenue data", error);
+  }
+  return fallback;
+}
+
+export async function fetchKpis(): Promise<Record<string, number> | null> {
+  const base = process.env.NEXT_PUBLIC_XANO_BASE;
+  if (!base) return null;
+  const url = `${base.replace(/\/$/, "")}/kpi/summary`;
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error("Bad status");
+    const data = await response.json();
+    return data as Record<string, number>;
+  } catch (error) {
+    console.error("Failed to load KPI summary", error);
+    return null;
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,41 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 47.4% 11.2%;
+
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 47.4% 11.2%;
+
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+
+  --ring: 215 20.2% 65.1%;
+
+  --radius: 0.75rem;
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,64 @@
+import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: ["./src/app/**/*.{ts,tsx}", "./src/components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [animate],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 App Router workspace with Tailwind, shadcn/ui primitives, and utility configs
- implement the /prospectus page with scenario toggles, revenue charts, PDF export, and qualitative prospectus copy
- add reusable UI components, API helpers with fallback demo data, and documentation for configuring the Xano base URL

## Testing
- not run (npm registry access returned 403, preventing dependency installation)


------
https://chatgpt.com/codex/tasks/task_e_68d6c018f024832ab22775a0a43a5095