### PR TITLE
Connect dashboard revenue to Xano

### DIFF
--- a/src/app/prospectus/page.tsx
+++ b/src/app/prospectus/page.tsx
@@ -25,11 +25,14 @@ export default function ProspectusPage() {
     setLoading(true);
     setError(null);
     try {
-      const [revenue, summary] = await Promise.all([fetchRevenue(selectedScenario), fetchKpis()]);
-      setData(revenue);
+      const [revenueResult, summary] = await Promise.all([
+        fetchRevenue(selectedScenario),
+        fetchKpis(),
+      ]);
+      setData(revenueResult.data);
       setKpis(summary);
-      if (!process.env.NEXT_PUBLIC_XANO_BASE) {
-        setError("NEXT_PUBLIC_XANO_BASE not set. Showing demo data.");
+      if (revenueResult.usedFallback) {
+        setError("Unable to load data from Xano. Showing demo data.");
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- pull revenue data from the Glowskill Xano endpoint, map it into chart-friendly records, and preserve scenario-based scaling with a fallback dataset
- update the prospectus dashboard loader to surface fallback messaging when backend data cannot be reached

## Testing
- npm install *(fails: 403 Forbidden fetching @radix-ui/react-select)*

------
https://chatgpt.com/codex/tasks/task_e_68d7166eb0dc832aa112e13db08859f5